### PR TITLE
Remove semicolon in default code

### DIFF
--- a/www/static/src/storage.js
+++ b/www/static/src/storage.js
@@ -87,7 +87,7 @@ function quick_load() {
         editor.setText(`use core {*}
 
 main :: () {
-    println("Hello, Onyx!");
+    println("Hello, Onyx!")
 }`);
         editor.clearSelection();
     }


### PR DESCRIPTION
Small edit to better reflect v0.1.11's removal of mandatory semicolons